### PR TITLE
Feature/fix csrf protections

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,14 +75,14 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.1)
     multi_json (1.13.1)
-    mustermann (1.0.2)
+    mustermann (1.0.3)
     nio4r (2.2.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     pg (0.19.0)
     puma (3.11.2)
-    rack (2.0.3)
-    rack-protection (2.0.1)
+    rack (2.0.5)
+    rack-protection (2.0.4)
       rack
     rack-test (0.8.2)
       rack (>= 1.0, < 3)
@@ -133,10 +133,10 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    sinatra (2.0.1)
+    sinatra (2.0.4)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.1)
+      rack-protection (= 2.0.4)
       tilt (~> 2.0)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -184,4 +184,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/README.md
+++ b/README.md
@@ -68,5 +68,16 @@ LINE DeveloperコンソールのChannel基本設定から、以下を設定。
 
 ※Webhook URLの `https://XXXXX.herokuapp.com` には `heroku create` で生成されたURLを指定する。Webhook URLを設定した後に接続確認ボタンを押して成功したら疎通完了。
 
+# Q&A
+## Q. herokuのログが見たい
+```
+$ heroku logs --tail
+```
+
+## Q. masterブランチ以外をherokuにデプロイしたい
+```
+$ git push heroku feature/xxxxx:master -f
+```
+
 # 参考
 ローカル環境構築は[こちら](https://github.com/giftee/intern-line-bot/wiki/%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E7%92%B0%E5%A2%83%E6%A7%8B%E7%AF%89)

--- a/README.md
+++ b/README.md
@@ -57,11 +57,6 @@ $ heroku config:set LINE_CHANNEL_SECRET=*****
 $ heroku config:set LINE_CHANNEL_TOKEN=*****
 ```
 
-7. シークレット情報の変更をherokuに反映させる。
-```
-$ git push heroku master
-```
-
 # LINE Developerコンソールの設定
 LINE DeveloperコンソールのChannel基本設定から、以下を設定。
 

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,7 +1,7 @@
 require 'line/bot'
 
 class WebhookController < ApplicationController
-  protect_from_forgery with: :null_session # CSRF対策無効化
+  protect_from_forgery except: [:callback] # CSRF対策無効化
 
   def client
     @client ||= Line::Bot::Client.new { |config|


### PR DESCRIPTION
# 背景
- CSRF検証のエラーが発生していた

```
2018-10-20T12:04:46.415030+00:00 app[web.1]: Can't verify CSRF token authenticity.
```

- sinatraのセキュリティアラートが飛んでいた
<img width="914" alt="2018-10-20 21 37 58" src="https://user-images.githubusercontent.com/5153062/47255733-7bbb3880-d4b0-11e8-8a0e-71cefd51772a.png">

# やったこと
- CSRF検証部分の修正
- sinatraのバージョンアップ
- READMEの修正
    - 「7. シークレット情報の変更をherokuに反映させる。」この手順が不要だった
        - ログを確認したところコマンド実行時にサーバの再起動が走っていた
    - Q&Aを追加