### PR TITLE
Upgrade ruby version to 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '>= 2.4.6', '< 2.7'
+ruby '2.7.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ DEPENDENCIES
   uglifier
 
 RUBY VERSION
-   ruby 2.6.0p0
+   ruby 2.7.0p0
 
 BUNDLED WITH
    1.17.2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # 環境
 ```
 $ ruby -v
-ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-darwin16]
+ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin19]
 
 $ bundle exec rails -v
 Rails 5.1.4

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140707111715) do
+ActiveRecord::Schema.define(version: 2014_07_07_111715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
## 実装の背景・目的
強い気持ちでRubyのバージョンを2.7に上げました。

## やったこと
1. Gemfile内のRubyバージョン指定を `2.7.0` に変更
2. ローカル環境構築を順番に行う(wiki参考)
https://github.com/giftee/intern-line-bot/wiki/%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E7%92%B0%E5%A2%83%E6%A7%8B%E7%AF%89
※bundlerのインストールは、wikiにある手順をそのまま行うと最新版 `2.1.4` が入ってしまったため、 `Gemfile.lock` に記載されているバージョン `1.17.2` を指定してインストールしました。
※bundlerのupgradeもしてしまって良さそうですが、やるにしても別PRにします。
```sh
# wikiにあるコマンド
$ rbenv exec gem install bundler
```
```sh
# このPRで行ったコマンド
$ rbenv exec gem install bundler:1.17.2
```

3. ローカル環境構築wikiを参考に、bundle installする(ここまでが ee9e4ea )
```sh
$ bundle exec bundle install --path=./vendor/bundle
```

4. ローカル環境構築を一通り行う(wikiにある 4. 5. を実行)
(ここで db/schema.rb の記述が変わったと思われます 513d5d0 )
5. READMEにあるWebhook環境の構築 を行い、オウム返しできることを確認

## キャプチャ
<img width="362" alt="スクリーンショット 2020-02-11 14 07 16" src="https://user-images.githubusercontent.com/30618030/74212499-d5fc9000-4cd7-11ea-8f65-c46056c52035.png">

## 補足
schema.rbのversion formatがどうしても変わってしまうのですがこれで良いのかな・・・ 🤔