### PR TITLE
Update bundler version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,4 +188,4 @@ RUBY VERSION
    ruby 2.7.0p0
 
 BUNDLED WITH
-   1.17.2
+   2.1.4


### PR DESCRIPTION
## 実装の背景・目的
(bundlerのversionをv2系に上げること)
#23 の関係で、今のmasterブランチの状態のままwikiの手順通りに `rbenv exec gem install bundler` すると `bundler v2.1.4` が入ってしまうことへの対応です。

## やったこと
↓の実行(参考：https://bundler.io/guides/bundler_2_upgrade.html#upgrading-applications-from-bundler-1-to-bundler-2 )
```sh
$ bundle update --bundler
```

## キャプチャ

## 補足
