### PR TITLE
本番環境のときはDotenvのgemを読み込まないようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 
 # Ignore ruby-version
 /.ruby-version
+
+# Ignore environment file.
+/.env*

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 ruby '2.7.0'
 
+gem 'dotenv-rails', groups: [:development, :test]
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~>6.0.2'
 # Use postgresql as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,10 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     execjs (2.7.0)
     ffi (1.12.2)
@@ -194,6 +198,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   coffee-rails
+  dotenv-rails
   jbuilder
   jquery-rails
   line-bot-api

--- a/app/models/Image.rb
+++ b/app/models/Image.rb
@@ -1,0 +1,6 @@
+module Image
+  FISH = "https://cookbiz.jp/soken/core/wp-content/uploads/2019/04/Fotolia_114908436_S.jpg"
+  DEEPFISH = "https://sp.hazardlab.jp/contents/post_info/2/4/6/24680/Blob.jpg"
+  SAD = "https://cdn.qetic.jp/wp-content/uploads/2019/12/12150212/music_191212_jindogg4.jpg"
+  ANGRY = "https://zbrush.zenryokuhp.com/bw_uploads/20110206.021.jpg"
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,9 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-Dotenv::Railtie.load
+if Rails.env.development? || Rails.env.test?
+  Dotenv::Railtie.load
+end
 
 module RubyGettingStarted
   class Application < Rails::Application

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,8 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+Dotenv::Railtie.load
+
 module RubyGettingStarted
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,4 +59,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.hosts << '.ngrok.io'
 end


### PR DESCRIPTION
## 実装の背景・目的

本番環境の時はDotenvのgemが読み込まれないので、Application.rbに記述した、Dotenvに関する記述を読み込まないようにした。

## やったこと

・Application.rbのDotenvに関する記述を本番環境で無効化
