### PR TITLE
add config.hosts for ngrok

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,7 @@ module RubyGettingStarted
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    config.hosts << /[a-z0-9]+\.ngrok\.io/
   end
 end


### PR DESCRIPTION
## 実装の背景・目的
Railsのアップデートに伴いconfig.hostsに登録されていないドメインからのアクセスをエラーにするように変更された。
その影響でngrok経由でアクセスするとRailsに弾かれて正常に動作しないという事象が発生

## やったこと
ngrok用のconfig.hostsを追加
(インターン生もngrok使うケースが多いし、無駄なところで時間取らせるのも申し訳ないので)
