### PR TITLE
ngrokのホスト定義をローカルのみに適用

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,5 @@ module RubyGettingStarted
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
-    config.hosts << /[a-z0-9]+\.ngrok\.io/
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,4 +59,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.hosts << /[a-z0-9]+\.ngrok\.io/
 end


### PR DESCRIPTION
## 実装の背景・目的
https://github.com/giftee/intern-line-bot/pull/33
こちらのPRでngrokの対応をしてくれているのですが、よく考えたらngrokをキックした攻撃ができてしまう気がしました。
ローカル環境だけならそのダメージも少ないと思うので制限しようと思います。

## 補足
- 多分動く。PRで見てくれ
