### PR TITLE
[仕様Level1] 特定のワードにのみ反応するようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 
 # Ignore ruby-version
 /.ruby-version
+
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'uglifier'
 gem 'coffee-rails'
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
 # gem 'therubyracer',  platforms: :ruby
-
+gem 'dotenv-rails'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,10 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.9.0)
     execjs (2.7.0)
     ffi (1.12.2)
@@ -194,6 +198,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   coffee-rails
+  dotenv-rails
   jbuilder
   jquery-rails
   line-bot-api

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -25,9 +25,13 @@ class WebhookController < ApplicationController
         case event.type
         when Line::Bot::Event::MessageType::Text
           message = {
-            type: 'text',
-            text: event.message['text']
+            type: 'text'
           }
+          if (event.message['text'] == '頭が痛いです')
+            message['text'] = 'お大事に'
+          else
+            message['text'] = '元気そうですね！'
+          end
           client.reply_message(event['replyToken'], message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message['id'])


### PR DESCRIPTION
## 実装の背景・目的
bot開発の仕様Level1に沿った実装。
[仕様書](https://giftee.docbase.io/posts/1588893#%E6%A9%9F%E8%83%BD%E4%BB%95%E6%A7%98%E3%83%AC%E3%83%99%E3%83%AB1-%E5%BF%85%E9%A0%88)

#### 目的
特定メッセージに対して、特定の応答を返すため。また、特定メッセージ以外は定形の応答を返すようにする。

## やったこと
- controller部分を変更
- クライアントからのメッセージを判定し、「頭が痛いです」というメッセージであれば「お大事に」と応答し、それ以外なら「元気そうですね！」というメッセージで応答するように

## キャプチャ
![Screenshot_20201027-160414_2](https://user-images.githubusercontent.com/44830504/97275168-ef9b3300-1878-11eb-94e9-d15448877f2b.png)

## 補足
- ngrokを使用してローカルでもデバッグできるようにしました
- deploy済です