### PR TITLE
refix ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.7.0'
+ruby '2.7.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~>6.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,7 @@ DEPENDENCIES
   uglifier
 
 RUBY VERSION
-   ruby 2.7.0p0
+   ruby 2.7.2p137
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
## 実装の背景・目的

herokuのスタックでruby 2.7.0のバージョンが打ち切りになり以下のエラーが出るようになっていた。
インターン生がスムーズに課題に集中できるようにrubyのバージョンを問題ない2.7.2にあげる
```
remote:  !
remote:  !     The Ruby version you are trying to install does not exist on this stack.
remote:  !     
remote:  !     You are trying to install ruby-2.7.0 on heroku-20.
remote:  !     
remote:  !     Ruby ruby-2.7.0 is present on the following stacks:
remote:  !     
remote:  !     - cedar-14
remote:  !     - heroku-16
remote:  !     - heroku-18
remote:  !     
remote:  !     Heroku recommends you use the latest supported Ruby version listed here:
remote:  !     https://devcenter.heroku.com/articles/ruby-support#supported-runtimes
remote:  !     
remote:  !     For more information on syntax for declaring a Ruby version see:
remote:  !     https://devcenter.heroku.com/articles/ruby-versions
remote:  !
```

## やったこと
ruby のバージョンを変更

## キャプチャ


## 補足
