### PR TITLE
Feature/bot responds with random image

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -10,6 +10,10 @@ class WebhookController < ApplicationController
     }
   end
 
+  def requesting_puzzle?(text)
+    text.match(/^(問題|もんだい)[出だ]して$/)
+  end
+
   def callback
     body = request.body.read
 
@@ -24,7 +28,7 @@ class WebhookController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
-          if event.message['text'] == '問題だして' then
+          if requesting_puzzle? event.message['text'] then
             message = {
               type: 'image',
               #　ランダムな猫の画像を返してくれるURL

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -38,10 +38,6 @@ class WebhookController < ApplicationController
             }
           end
           client.reply_message(event['replyToken'], message)
-        when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
-          response = client.get_message_content(event.message['id'])
-          tf = Tempfile.open("content")
-          tf.write(response.body)
         end
       end
     }

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -24,10 +24,19 @@ class WebhookController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
-          message = {
-            type: 'text',
-            text: event.message['text']
-          }
+          if event.message['text'] == '問題だして' then
+            message = {
+              type: 'image',
+              #　ランダムな猫の画像を返してくれるURL
+              originalContentUrl: 'https://placekitten.com/400/400',
+              previewImageUrl: 'https://placekitten.com/200/200'
+            }
+          elsif 
+            message = {
+              type: 'text',
+              text: 'すみません。よくわかりません。'
+            }
+          end
           client.reply_message(event['replyToken'], message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message['id'])


### PR DESCRIPTION
## 実装の背景・目的
[仕様レベル1](https://giftee.docbase.io/posts/1805491#%E6%A9%9F%E8%83%BD%E4%BB%95%E6%A7%98%E3%83%AC%E3%83%99%E3%83%AB1-%E5%BF%85%E9%A0%88)を実装するべく、まずは「問題だして」といったら画像を返答するようにした

## やったこと

- 「問題出して」といったら[ランダムな猫画像](https://placekitten.com/)が送られてくるようにした
-  問題、もんだい、だして、出してとかの表記のバリエーションに対応した
- 特定の文字以外のテキストがきたら「すみません。よくわかりません。」と答えるようにした
- テキストメッセージ以外のイベントには反応しなくした

## 質問

- 「問題」、「もんだい」などのバリエーションに対応するのは今のところコントローラーにその関数を持たせてるけど、応答するメッセージの種類が増えてきたら、今のまま膨らましていくとしんどい気がするけどどうでしょう。。うまく切り分ける方法があれば教えてください。
