### PR TITLE
Feat: dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 
 # Ignore ruby-version
 /.ruby-version
+
+# Dotenv file
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -44,3 +44,5 @@ gem 'sinatra'
 gem 'bootsnap', require: false
 
 gem 'listen', group: :development
+
+gem 'dotenv-rails', group: [:development]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,10 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     execjs (2.7.0)
     ffi (1.12.2)
@@ -194,6 +198,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   coffee-rails
+  dotenv-rails
   jbuilder
   jquery-rails
   line-bot-api


### PR DESCRIPTION
## 実装の背景・目的

ローカルで開発時に、環境変数の指定を自動的に行うために、
dotenvをプロジェクトに追加した。

## やったこと

- `rails-dotenv`の依存関係を追加

## 補足

- Herokuへのデプロイ時には`.env`ファイルをアップロードできないため、開発時のみに必要なライブラリとして追加しています。
