### PR TITLE
個人チャットから飲食店を検索し，グループチャットに送信

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 
 # Ignore ruby-version
 /.ruby-version
+
+# 環境変数
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -44,3 +44,6 @@ gem 'sinatra'
 gem 'bootsnap', require: false
 
 gem 'listen', group: :development
+
+# 環境変数ようのgemを作成
+gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,10 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     execjs (2.7.0)
     ffi (1.12.2)
@@ -194,6 +198,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   coffee-rails
+  dotenv-rails
   jbuilder
   jquery-rails
   line-bot-api

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,4 +1,7 @@
+require 'json'
 require 'line/bot'
+require 'net/http'
+require 'uri'
 
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
@@ -10,9 +13,24 @@ class WebhookController < ApplicationController
     }
   end
 
+  # 飲食店検索
+  def food_search_api(place, food)
+    data = {
+      "key": "01458b22b6dce274",
+      "address": place,
+      "keyword": food
+    }
+    query = data.to_query
+    uri = URI("http://webservice.recruit.co.jp/hotpepper/gourmet/v1/?" + query)
+    http = Net::HTTP.new(uri.host, uri.port)
+    req = Net::HTTP::Get.new(uri)
+    res = http.request(req)
+    res_data = Hash.from_xml(res.body)
+    return res_data
+  end
+
   def callback
     body = request.body.read
-
     signature = request.env['HTTP_X_LINE_SIGNATURE']
     unless client.validate_signature(body, signature)
       head 470
@@ -24,11 +42,35 @@ class WebhookController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
+          text = event.message['text'].split("、")
+          place = text[0]
+          food = text[1]
+          res_data = food_search_api(place, food)
+
+          hello_content = <<~EOS
+          久しぶり〜！今度みんなでご飯でもどう？
+          #{place}でお勧めの#{food}を紹介するね！
+          EOS
+
           message = {
             type: 'text',
-            text: event.message['text']
+            text: hello_content
           }
           client.push_message(ENV['GROUP_ID'], message)
+
+          for i in 0..2 do
+            recommend_store = <<~EOS
+            店名： #{res_data['results']['shop'][i]['name']}
+            最寄駅： #{res_data['results']['shop'][i]['station_name']}
+            URL： #{res_data['results']['shop'][i]['urls']['pc']}
+            EOS
+            message = {
+              type: 'text',
+              text: recommend_store
+            }
+            client.push_message(ENV['GROUP_ID'], message)
+          end
+        
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message['id'])
           tf = Tempfile.open("content")

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -26,7 +26,7 @@ class WebhookController < ApplicationController
         when Line::Bot::Event::MessageType::Text
           message = {
             type: 'text',
-            text: event.message['text']
+            text: "userId: " + event['source']['userId'] + "\n" + "groupId: " + event['source']['groupId']
           }
           client.reply_message(event['replyToken'], message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -26,9 +26,9 @@ class WebhookController < ApplicationController
         when Line::Bot::Event::MessageType::Text
           message = {
             type: 'text',
-            text: "userId: " + event['source']['userId'] + "\n" + "groupId: " + event['source']['groupId']
+            text: event.message['text']
           }
-          client.reply_message(event['replyToken'], message)
+          client.push_message(ENV['GROUP_ID'], message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message['id'])
           tf = Tempfile.open("content")

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,5 +59,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-  config.hosts << /[a-z0-9]+\.ngrok\.io/
+  config.hosts << '.ngrok.io'
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,5 +59,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-  config.hosts << '.ngrok.io'
+  config.hosts << /[a-zA-Z0-9]+\.ngrok\.io/
 end


### PR DESCRIPTION
## 実装の背景・目的

個人チャットの内容からHot Pepperのグルメ検索APIを用いてお勧めの飲食店を検索し，その結果をグループチャットに送信．

## やったこと

- webhook_controller.rbにfood_search_api関数を作成
- webhook_controller.rbのcallback関数の送信内容を変更

## キャプチャ

![個人チャットで場所と料理を送信](https://user-images.githubusercontent.com/82089820/143174006-663f7212-3ede-42eb-bfcb-d3693925e594.png)

![グループチャットに結果を送信](https://user-images.githubusercontent.com/82089820/143174038-78fd60bb-2839-413a-9263-d5f7a11a212b.png)

## 補足

- 送信するときに「場所、料理」と送らなければ，反応がない．(修正が必要)
