### PR TITLE
ngrokが動くように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ $ git push heroku feature/xxxxx:master -f
 ```
 
 ## Q. LINE Messaging APIの動作確認をローカル環境でできますか？
-A. ngrokというツールを使うとできます
+A. [ngrok](https://ngrok.com/)というツールを使うとできます

--- a/README.md
+++ b/README.md
@@ -73,3 +73,5 @@ $ heroku logs --tail
 $ git push heroku feature/xxxxx:master -f
 ```
 
+## Q. LINE Messaging APIの動作確認をローカル環境でできますか？
+A. ngrokというツールを使うとできます

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,5 +59,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-  config.hosts << /[a-z0-9]+\.ngrok\.io/
+  config.hosts << '.ngrok.io'
 end


### PR DESCRIPTION
## 実装の背景・目的
- `xxx_yyy.ngrok.io`のようにアンダースコアが入っている場合にhostが弾かれてしまうため、エラーにならないように修正する
- READMEでngrokについて言及しておく
