### PR TITLE
ngrok のドメインが変わったので、.jp.ngrok.io を接続先ホストとして許可する

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,5 +59,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-  config.hosts << '.ngrok.io'
+  config.hosts << '.jp.ngrok.io'
 end


### PR DESCRIPTION
## 実装の背景・目的
ngrok のドメインが変わったので、.jp.ngrok.io を接続先ホストとして許可します

レビューをしてもらうにあたり、どのような理由や目的からコードを変更したのか書いてください

ngrok のドメインが `.ngrok.io` から `.jp.ngrok.io`  に変わっていました。
現状 `.ngrok.io` が接続先ホストとして登録されていますが、これでは `.jp.ngrok.io` はブロックされてしまいます。

## やったこと
`.ngrok.io` の代わりに `.jp.ngrok.io` を接続先ホストとして許可しました

