### PR TITLE
renderデプロイできるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ bundle exec rake secret
 - 自身のgithubアカウントでログイン(推奨)
 
 3. render上でデータベースを作成する
-- New+ ボタンからPostgresを選択
+- New+ ボタンからPostgreSQLを選択
 - 任意の名前を入力
 
 4. render上でアプリサーバーを作成する。
-- WebServicesを選択
+- Web Serviceを選択
 - githubログインしない場合は、webサービス作成画面にてgithubアカウントを`connect`する。
 - intern-line-botのリポジトリを選択する。
 - サービス名を入力
@@ -40,7 +40,7 @@ bundle exec rake secret
 - 環境変数を設定する
   - WebService作成画面の下部にある`Advanced`ボタンを押す
     - (key)
-    - DATABASE_URL(render上で作成したpostgresのダッシュボードからInternal Database URLを取得)
+    - DATABASE_URL(render上で作成したPostgreSQLのダッシュボードからInternal Database URLを取得)
     - LINE_CHANNEL_SECRET(LINE developer コンソールのChannel基本設定から取得)
     - LINE_CHANNEL_TOKEN(LINE developer コンソールのChannel基本設定から取得)
     - SECRET_KEY_BASE(bundle exec rake secretで生成したもの)
@@ -58,5 +58,3 @@ LINE DeveloperコンソールのChannel基本設定から、以下を設定。
 
 ## Q. LINE Messaging APIの動作確認をローカル環境でできますか？
 A. [ngrok](https://ngrok.com/)というツールを使うとできます
-
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # 前提
-- [Heroku](https://jp.heroku.com/) のアカウントを取得済みであること。
-- Herokuの[CLIツール](https://devcenter.heroku.com/articles/getting-started-with-ruby#set-up)がインストール済みであること。
+- [render](https://render.com/) のアカウントを取得済みであること。
 - [LINE Developer](https://developers.line.me/ja/) 登録が完了し、プロバイダー・channelの作成が完了していること。
 
 # 環境
@@ -14,64 +13,65 @@ Rails 6.0.2.1
 # rails 環境構築
 [こちら](https://github.com/giftee/intern-line-bot/wiki/%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E7%92%B0%E5%A2%83%E6%A7%8B%E7%AF%89) を参考にローカルで rails アプリケーションが動くようにする
 
-# Webhook環境の構築
-1. Herokuにログインする。
-```
-$ heroku login
-heroku: Press any key to open up the browser to login or q to exit:
+# デプロイ準備
+
+1. `puma.rb`を修正
+```rb
+workers ENV.fetch("WEB_CONCURRENCY") { 4 }
+preload_app!
 ```
 
-2. heroku上にアプリを作成する。
-```
-$ heroku create
-Creating app... done, ⬢ XXXXX    // XXXXX はランダムな文字列が生成される。
-https://XXXXX.herokuapp.com/ | https://git.heroku.com/XXXXX.git
-
-$ git remote -v
-heroku	https://git.heroku.com/XXXXX.git (fetch)
-heroku	https://git.heroku.com/XXXXX.git (push)
-origin	git@github.com:{user name}/intern-line-bot.git (fetch)
-origin	git@github.com:{user name}/intern-line-bot.git (push)
+2. `config/environments/production.rb`を修正
+```rb
+config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present? || ENV['RENDER'].present?
 ```
 
-3. herokuに資源をデプロイする。
-```
-$ git push heroku master
+3. renderでbuildするための設定ファイルを作成する
+- `bin`配下に`render-build.sh`を作成。
+- 中身は以下
+```rb
+#!/usr/bin/env bash
+# exit on error
+set -o errexit
+
+bundle install
+bundle exec rake assets:precompile
+bundle exec rake assets:clean
+bundle exec rake db:migrate
 ```
 
-4. heroku上にアプリが公開されたか確認する。
+4. 作成したbuildファイルに実行権限を付与
 ```
-$ heroku open
+chmod a+x bin/render-build.sh
 ```
 
-5. LINE Messaging APIにアクセスするためのシークレット情報を登録する。
-LINE developer コンソールのChannel基本設定から「Channel Secret」と「アクセストークン」を取得し、以下の通り設定する。
+5. railsのシークレットキーを発行する
 ```
-$ heroku config:set LINE_CHANNEL_SECRET=*****
-$ heroku config:set LINE_CHANNEL_TOKEN=*****
+bundle exec rake secret
 ```
+
+6. render上にアプリを作成する。
+- WebServicesを選択
+- 任意の名前と以下のBuildCommand/StartCommandを入力
+  - BuildCommand: `./bin/render-build.sh`
+  - StartCommand: `bundle exec puma -C config/puma.rb`
+
+- 環境変数を設定する
+  - (key)
+  - LINE_CHANNEL_SECRET(LINE developer コンソールのChannel基本設定から取得)
+  - LINE_CHANNEL_TOKEN(LINE developer コンソールのChannel基本設定から取得)
+  - SECRET_KEY_BASE(bundle exec rake secretで生成したもの)
 
 # LINE Developerコンソールの設定
 LINE DeveloperコンソールのChannel基本設定から、以下を設定。
 
 - Webhook送信: 利用する
-- Webhook URL: https://XXXXX.herokuapp.com/callback
+- Webhook URL: `https://XXXXXXXXXXX.onrender.com`
 - Botのグループトーク参加: 利用する
 - 自動応答メッセージ: 利用しない
 - 友だち追加時あいさつ: 利用する
 
-※Webhook URLの `https://XXXXX.herokuapp.com` には `heroku create` で生成されたURLを指定する。Webhook URLを設定した後に接続確認ボタンを押して成功したら疎通完了。
-
-# Q&A
-## Q. herokuのログが見たい
-```
-$ heroku logs --tail
-```
-
-## Q. masterブランチ以外をherokuにデプロイしたい
-```
-$ git push heroku feature/xxxxx:master -f
-```
+※Webhook URLの `https://XXXXXXXXXXX.onrender.com` には renderで作成したサービスのダッシュボード上部に記載されているURLを入力。Webhook URLを設定した後に接続確認ボタンを押して成功したら疎通完了。
 
 ## Q. LINE Messaging APIの動作確認をローカル環境でできますか？
 A. [ngrok](https://ngrok.com/)というツールを使うとできます

--- a/README.md
+++ b/README.md
@@ -15,63 +15,48 @@ Rails 6.0.2.1
 
 # デプロイ準備
 
-1. `puma.rb`を修正
-```rb
-workers ENV.fetch("WEB_CONCURRENCY") { 4 }
-preload_app!
-```
-
-2. `config/environments/production.rb`を修正
-```rb
-config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present? || ENV['RENDER'].present?
-```
-
-3. renderでbuildするための設定ファイルを作成する
-- `bin`配下に`render-build.sh`を作成。
-- 中身は以下
-```rb
-#!/usr/bin/env bash
-# exit on error
-set -o errexit
-
-bundle install
-bundle exec rake assets:precompile
-bundle exec rake assets:clean
-bundle exec rake db:migrate
-```
-
-4. 作成したbuildファイルに実行権限を付与
-```
-chmod a+x bin/render-build.sh
-```
-
-5. railsのシークレットキーを発行する
+1. railsのシークレットキーを発行する
 ```
 bundle exec rake secret
 ```
 
-6. render上にアプリを作成する。
+2. renderにログインする
+- 自身のgithubアカウントでログイン(推奨)
+
+3. render上でデータベースを作成する
+- New+ ボタンからPostgresを選択
+- 任意の名前を入力
+
+4. render上でアプリサーバーを作成する。
 - WebServicesを選択
-- 任意の名前と以下のBuildCommand/StartCommandを入力
+- githubログインしない場合は、webサービス作成画面にてgithubアカウントを`connect`する。
+- intern-line-botのリポジトリを選択する。
+- サービス名を入力
+- pushしたいブランチを選択
+- 以下のBuildCommand/StartCommandを入力
   - BuildCommand: `./bin/render-build.sh`
   - StartCommand: `bundle exec puma -C config/puma.rb`
 
 - 環境変数を設定する
-  - (key)
-  - LINE_CHANNEL_SECRET(LINE developer コンソールのChannel基本設定から取得)
-  - LINE_CHANNEL_TOKEN(LINE developer コンソールのChannel基本設定から取得)
-  - SECRET_KEY_BASE(bundle exec rake secretで生成したもの)
+  - WebService作成画面の下部にある`Advanced`ボタンを押す
+    - (key)
+    - DATABASE_URL(render上で作成したpostgresのダッシュボードからInternal Database URLを取得)
+    - LINE_CHANNEL_SECRET(LINE developer コンソールのChannel基本設定から取得)
+    - LINE_CHANNEL_TOKEN(LINE developer コンソールのChannel基本設定から取得)
+    - SECRET_KEY_BASE(bundle exec rake secretで生成したもの)
 
 # LINE Developerコンソールの設定
 LINE DeveloperコンソールのChannel基本設定から、以下を設定。
 
 - Webhook送信: 利用する
-- Webhook URL: `https://XXXXXXXXXXX.onrender.com`
+- Webhook URL: `https://XXXXXXXXXXX.onrender.com/callback`
 - Botのグループトーク参加: 利用する
 - 自動応答メッセージ: 利用しない
 - 友だち追加時あいさつ: 利用する
 
-※Webhook URLの `https://XXXXXXXXXXX.onrender.com` には renderで作成したサービスのダッシュボード上部に記載されているURLを入力。Webhook URLを設定した後に接続確認ボタンを押して成功したら疎通完了。
+※Webhook URLには renderで作成したサービスのダッシュボード上部に記載されているURLに`/callback`をつけたものを入力。Webhook URLを設定した後に接続確認ボタンを押して成功したら疎通完了。
 
 ## Q. LINE Messaging APIの動作確認をローカル環境でできますか？
 A. [ngrok](https://ngrok.com/)というツールを使うとできます
+
+

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# exit on error
+set -o errexit
+
+bundle install
+bundle exec rake assets:precompile
+bundle exec rake assets:clean
+bundle exec rake db:migrate

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present? || ENV['RENDER'].present?
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -25,14 +25,15 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-# preload_app!
+preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
## 実装の背景・目的
- Heroku無料枠がが11月いっぱいで終了することを受けて、インターン向けのインフラをRender.comに切り替えることになった。。

## やったこと
- renderでdeployする方法をREADMEに記述した。
- render上にdeployするための設定を追記した。(参考：https://render.com/docs/deploy-rails#deploy-to-render)

## 補足
- 手元で、deployできることを確認してくれています。

- 補足事項があれば
- [ ] やることリストでも OK
