### PR TITLE
chatGPTの導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 
 # Ignore ruby-version
 /.ruby-version
+
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -53,3 +53,9 @@ gem 'psych', '< 4'
 gem 'net-smtp', require: false
 gem 'net-imap', require: false
 gem 'net-pop', require: false
+
+gem 'dotenv-rails'
+
+gem 'pry-rails'
+
+gem 'ruby-openai'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
     bootsnap (1.13.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
       railties (>= 5.2.0)
@@ -68,8 +69,18 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.11.0)
     execjs (2.8.1)
+    faraday (2.7.4)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
+    faraday-net_http (3.0.2)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -97,6 +108,7 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.16.3)
     msgpack (1.6.0)
+    multipart-post (2.3.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     net-imap (0.3.1)
@@ -112,6 +124,11 @@ GEM
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     pg (0.21.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     psych (3.3.4)
     puma (6.0.0)
       nio4r (~> 2.0)
@@ -157,6 +174,9 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rdoc (6.3.3)
+    ruby-openai (4.1.0)
+      faraday (>= 1)
+      faraday-multipart (>= 1)
     ruby2_keywords (0.0.5)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -205,6 +225,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   coffee-rails
+  dotenv-rails
   jbuilder
   jquery-rails
   line-bot-api
@@ -213,10 +234,12 @@ DEPENDENCIES
   net-pop
   net-smtp
   pg (~> 0.18)
+  pry-rails
   psych (< 4)
   puma
   rails (~> 6.0.2)
   rails_12factor
+  ruby-openai
   sass-rails
   sdoc
   sinatra

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -27,7 +27,6 @@ class WebhookController < ApplicationController
         when Line::Bot::Event::MessageType::Text
           message = {
             type: 'text',
-            ##text: reply_to_message()
             text: reply_to_message(event.message['text'])
           }
           client.reply_message(event['replyToken'], message)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,5 +59,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-  config.hosts << '.jp.ngrok.io'
+  config.hosts << '.ngrok-free.app'
 end


### PR DESCRIPTION
## 実装の背景・目的

オウム返しボットを作るための環境構築とchatGPTを用いて、lineで聞くとchatGPTの答えが返ってくるように実装した。

## やったこと

- PR 内でやったことを箇条書きにしてください
- 環境構築
- ライブラリのインストール
- chatGPTの答えを返すreply_to_messageメソッドを作成
- 

## キャプチャ

![IMG_1312](https://github.com/giftee/intern-line-bot/assets/111235310/272ea53a-a13f-4e26-8505-eb1f3a59ae06)


## 補足

- 補足事項があれば
- [ ] やることリストでも OK
