### PR TITLE
ngrok のドメインが新しくなってるので更新

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,5 +59,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-  config.hosts << '.jp.ngrok.io'
+  config.hosts << '.ngrok-free.app'
 end


### PR DESCRIPTION
## 実装の背景・目的
- ngrok 使ってみたらドメインが変わっていてアクセスできなかった
- これを解消したい

## やったこと
- development の config hosts を `.jp.ngrok.io`から`.ngrok-free.app`に変更
- 有料版だと違うドメインになるが、インターン生は基本的に無料版を利用すると思われるのでこれで

## キャプチャ
2023/12 現在の ngrok のドメイン
<img width="785" alt="image" src="https://github.com/giftee/intern-line-bot/assets/39614159/8fd24697-dba1-42c0-96d1-a63295974fd2">

## 補足
ngrok 管理のドメイン一覧
https://ngrok.com/docs/network-edge/domains-and-tcp-addresses/#ngrok-managed-domains

`.dev`の使い方がわからない...
けど起動するとデフォルトは`.app`ぽいので一旦無視

<img width="859" alt="image" src="https://github.com/giftee/intern-line-bot/assets/39614159/8ae2c22f-3ed8-4fea-8787-8c4dc1fdb5a9">
